### PR TITLE
feat: Add thread-safe rate limit tracker (Issue #4)

### DIFF
--- a/src/main/java/com/bavodaniels/ratelimit/tracker/RateLimitException.java
+++ b/src/main/java/com/bavodaniels/ratelimit/tracker/RateLimitException.java
@@ -1,0 +1,17 @@
+package com.bavodaniels.ratelimit.tracker;
+
+/**
+ * Exception thrown when a request is rate limited and the wait time exceeds the configured threshold.
+ *
+ * @since 1.0.0
+ */
+public class RateLimitException extends Exception {
+
+    public RateLimitException(String message) {
+        super(message);
+    }
+
+    public RateLimitException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/bavodaniels/ratelimit/tracker/RateLimitState.java
+++ b/src/main/java/com/bavodaniels/ratelimit/tracker/RateLimitState.java
@@ -1,0 +1,59 @@
+package com.bavodaniels.ratelimit.tracker;
+
+import java.time.Instant;
+
+/**
+ * Immutable class representing the rate limit state for a specific host/endpoint.
+ * Thread-safe due to immutability.
+ *
+ * @since 1.0.0
+ */
+public record RateLimitState(
+    int limit,
+    int remaining,
+    Instant resetTime,
+    Instant lastUpdated
+) {
+
+    /**
+     * Creates a new RateLimitState with the current timestamp.
+     *
+     * @param limit the rate limit (max requests allowed)
+     * @param remaining the number of requests remaining
+     * @param resetTime when the rate limit will reset
+     * @return a new RateLimitState instance
+     */
+    public static RateLimitState of(int limit, int remaining, Instant resetTime) {
+        return new RateLimitState(limit, remaining, resetTime, Instant.now());
+    }
+
+    /**
+     * Checks if this rate limit state has expired (reset time has passed).
+     *
+     * @return true if the rate limit has reset, false otherwise
+     */
+    public boolean isExpired() {
+        return Instant.now().isAfter(resetTime);
+    }
+
+    /**
+     * Checks if requests are currently being rate limited (remaining is 0).
+     *
+     * @return true if no requests remain, false otherwise
+     */
+    public boolean isLimited() {
+        return remaining <= 0;
+    }
+
+    /**
+     * Calculates the time in milliseconds until the rate limit resets.
+     *
+     * @return milliseconds until reset, or 0 if already reset
+     */
+    public long getWaitTimeMillis() {
+        if (isExpired()) {
+            return 0;
+        }
+        return resetTime.toEpochMilli() - Instant.now().toEpochMilli();
+    }
+}

--- a/src/main/java/com/bavodaniels/ratelimit/tracker/RateLimitTracker.java
+++ b/src/main/java/com/bavodaniels/ratelimit/tracker/RateLimitTracker.java
@@ -1,0 +1,153 @@
+package com.bavodaniels.ratelimit.tracker;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Thread-safe tracker for rate limit states across different hosts and endpoints.
+ * Uses ConcurrentHashMap for lock-free reads and atomic updates.
+ *
+ * @since 1.0.0
+ */
+@Component
+public class RateLimitTracker {
+
+    private final ConcurrentHashMap<String, RateLimitState> rateLimits = new ConcurrentHashMap<>();
+    private final Duration waitThreshold;
+
+    /**
+     * Creates a new RateLimitTracker with default wait threshold of 5 seconds.
+     */
+    public RateLimitTracker() {
+        this(Duration.ofSeconds(5));
+    }
+
+    /**
+     * Creates a new RateLimitTracker with specified wait threshold.
+     *
+     * @param waitThreshold the maximum time to wait before throwing an exception
+     */
+    public RateLimitTracker(Duration waitThreshold) {
+        this.waitThreshold = waitThreshold;
+    }
+
+    /**
+     * Updates the rate limit state for a given key.
+     * Uses atomic compute operation to ensure thread-safety.
+     *
+     * @param key the key (typically "host:endpoint" or just "host")
+     * @param limit the rate limit (max requests allowed)
+     * @param remaining the number of requests remaining
+     * @param resetTime when the rate limit will reset
+     */
+    public void updateRateLimit(String key, int limit, int remaining, Instant resetTime) {
+        rateLimits.compute(key, (k, oldState) -> {
+            // Always update with new information from the server
+            return RateLimitState.of(limit, remaining, resetTime);
+        });
+    }
+
+    /**
+     * Checks if a request should proceed or be blocked based on rate limit state.
+     * If the wait time is less than the threshold, this method will block until the reset.
+     * If the wait time exceeds the threshold, a RateLimitException is thrown.
+     *
+     * @param key the key (typically "host:endpoint" or just "host")
+     * @return true if the request can proceed, false if there's no rate limit info
+     * @throws RateLimitException if rate limited and wait time exceeds threshold
+     * @throws InterruptedException if the thread is interrupted while waiting
+     */
+    public boolean checkAndWait(String key) throws RateLimitException, InterruptedException {
+        RateLimitState state = rateLimits.get(key);
+
+        // No rate limit info - allow request
+        if (state == null) {
+            return true;
+        }
+
+        // Rate limit expired - allow request
+        if (state.isExpired()) {
+            return true;
+        }
+
+        // Not rate limited - allow request
+        if (!state.isLimited()) {
+            return true;
+        }
+
+        // Rate limited - check wait time
+        long waitTimeMillis = state.getWaitTimeMillis();
+
+        if (waitTimeMillis <= 0) {
+            // Reset time has passed
+            return true;
+        }
+
+        if (waitTimeMillis > waitThreshold.toMillis()) {
+            // Wait time exceeds threshold - throw exception
+            throw new RateLimitException(
+                String.format("Rate limit exceeded for %s. Reset in %d ms (threshold: %d ms)",
+                    key, waitTimeMillis, waitThreshold.toMillis())
+            );
+        }
+
+        // Wait time within threshold - block and wait
+        TimeUnit.MILLISECONDS.sleep(waitTimeMillis);
+        return true;
+    }
+
+    /**
+     * Gets the current rate limit state for a key.
+     *
+     * @param key the key to look up
+     * @return the current RateLimitState or null if not found
+     */
+    public RateLimitState getState(String key) {
+        return rateLimits.get(key);
+    }
+
+    /**
+     * Removes expired rate limit entries.
+     * This method is called automatically every minute by Spring's scheduler.
+     * Can also be called manually for testing or immediate cleanup.
+     */
+    @Scheduled(fixedRate = 60000) // Run every minute
+    public void cleanupExpiredEntries() {
+        rateLimits.entrySet().removeIf(entry -> entry.getValue().isExpired());
+    }
+
+    /**
+     * Clears all rate limit state. Useful for testing.
+     */
+    public void clear() {
+        rateLimits.clear();
+    }
+
+    /**
+     * Gets the number of tracked rate limits.
+     *
+     * @return the number of entries in the tracker
+     */
+    public int size() {
+        return rateLimits.size();
+    }
+
+    /**
+     * Builds a key from host and endpoint.
+     *
+     * @param host the host (e.g., "api.example.com")
+     * @param endpoint the endpoint (e.g., "/users")
+     * @return the combined key (e.g., "api.example.com:/users")
+     */
+    public static String buildKey(String host, String endpoint) {
+        if (endpoint == null || endpoint.isEmpty()) {
+            return host;
+        }
+        return host + ":" + endpoint;
+    }
+}

--- a/src/test/java/com/bavodaniels/ratelimit/tracker/RateLimitStateTest.java
+++ b/src/test/java/com/bavodaniels/ratelimit/tracker/RateLimitStateTest.java
@@ -1,0 +1,90 @@
+package com.bavodaniels.ratelimit.tracker;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RateLimitStateTest {
+
+    @Test
+    void testCreation() {
+        Instant resetTime = Instant.now().plusSeconds(60);
+        RateLimitState state = RateLimitState.of(100, 50, resetTime);
+
+        assertEquals(100, state.limit());
+        assertEquals(50, state.remaining());
+        assertEquals(resetTime, state.resetTime());
+        assertNotNull(state.lastUpdated());
+    }
+
+    @Test
+    void testIsExpired_NotExpired() {
+        Instant resetTime = Instant.now().plusSeconds(60);
+        RateLimitState state = RateLimitState.of(100, 50, resetTime);
+
+        assertFalse(state.isExpired());
+    }
+
+    @Test
+    void testIsExpired_Expired() {
+        Instant resetTime = Instant.now().minusSeconds(1);
+        RateLimitState state = RateLimitState.of(100, 50, resetTime);
+
+        assertTrue(state.isExpired());
+    }
+
+    @Test
+    void testIsLimited_NotLimited() {
+        Instant resetTime = Instant.now().plusSeconds(60);
+        RateLimitState state = RateLimitState.of(100, 50, resetTime);
+
+        assertFalse(state.isLimited());
+    }
+
+    @Test
+    void testIsLimited_Limited() {
+        Instant resetTime = Instant.now().plusSeconds(60);
+        RateLimitState state = RateLimitState.of(100, 0, resetTime);
+
+        assertTrue(state.isLimited());
+    }
+
+    @Test
+    void testIsLimited_NegativeRemaining() {
+        Instant resetTime = Instant.now().plusSeconds(60);
+        RateLimitState state = RateLimitState.of(100, -1, resetTime);
+
+        assertTrue(state.isLimited());
+    }
+
+    @Test
+    void testGetWaitTimeMillis_Future() {
+        Instant resetTime = Instant.now().plus(5, ChronoUnit.SECONDS);
+        RateLimitState state = RateLimitState.of(100, 0, resetTime);
+
+        long waitTime = state.getWaitTimeMillis();
+        assertTrue(waitTime > 0);
+        assertTrue(waitTime <= 5000); // Should be roughly 5 seconds
+    }
+
+    @Test
+    void testGetWaitTimeMillis_Expired() {
+        Instant resetTime = Instant.now().minusSeconds(1);
+        RateLimitState state = RateLimitState.of(100, 0, resetTime);
+
+        assertEquals(0, state.getWaitTimeMillis());
+    }
+
+    @Test
+    void testImmutability() {
+        Instant resetTime = Instant.now().plusSeconds(60);
+        RateLimitState state = RateLimitState.of(100, 50, resetTime);
+
+        // Record fields are final and can't be modified
+        assertEquals(100, state.limit());
+        assertEquals(50, state.remaining());
+    }
+}

--- a/src/test/java/com/bavodaniels/ratelimit/tracker/RateLimitTrackerConcurrencyTest.java
+++ b/src/test/java/com/bavodaniels/ratelimit/tracker/RateLimitTrackerConcurrencyTest.java
@@ -1,0 +1,360 @@
+package com.bavodaniels.ratelimit.tracker;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Thread-safety tests for RateLimitTracker with 100+ concurrent threads.
+ * Tests concurrent reads, writes, and mixed operations.
+ */
+class RateLimitTrackerConcurrencyTest {
+
+    private RateLimitTracker tracker;
+    private ExecutorService executorService;
+
+    @BeforeEach
+    void setUp() {
+        tracker = new RateLimitTracker(Duration.ofSeconds(5));
+        executorService = Executors.newFixedThreadPool(150);
+    }
+
+    @Test
+    void testConcurrentUpdates_100Threads() throws InterruptedException {
+        int threadCount = 100;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(threadCount);
+
+        Instant resetTime = Instant.now().plusSeconds(60);
+
+        for (int i = 0; i < threadCount; i++) {
+            final int threadId = i;
+            executorService.submit(() -> {
+                try {
+                    startLatch.await(); // Wait for all threads to be ready
+                    tracker.updateRateLimit("api.example.com", 100, threadId, resetTime);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    endLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown(); // Start all threads
+        assertTrue(endLatch.await(10, TimeUnit.SECONDS));
+
+        // Verify tracker has the entry and is in a valid state
+        RateLimitState state = tracker.getState("api.example.com");
+        assertNotNull(state);
+        assertEquals(100, state.limit());
+        // The remaining value will be from one of the threads (0-99)
+        assertTrue(state.remaining() >= 0 && state.remaining() < threadCount);
+    }
+
+    @Test
+    void testConcurrentReads_200Threads() throws InterruptedException {
+        Instant resetTime = Instant.now().plusSeconds(60);
+        tracker.updateRateLimit("api.example.com", 100, 50, resetTime);
+
+        int threadCount = 200;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    startLatch.await();
+                    RateLimitState state = tracker.getState("api.example.com");
+                    if (state != null && state.limit() == 100 && state.remaining() == 50) {
+                        successCount.incrementAndGet();
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    endLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        assertTrue(endLatch.await(10, TimeUnit.SECONDS));
+
+        // All threads should have read the same consistent state
+        assertEquals(threadCount, successCount.get());
+    }
+
+    @Test
+    void testConcurrentCheckAndWait_150Threads_NotLimited() throws InterruptedException {
+        Instant resetTime = Instant.now().plusSeconds(60);
+        tracker.updateRateLimit("api.example.com", 100, 50, resetTime);
+
+        int threadCount = 150;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger exceptionCount = new AtomicInteger(0);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    startLatch.await();
+                    boolean result = tracker.checkAndWait("api.example.com");
+                    if (result) {
+                        successCount.incrementAndGet();
+                    }
+                } catch (RateLimitException e) {
+                    exceptionCount.incrementAndGet();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    endLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        assertTrue(endLatch.await(10, TimeUnit.SECONDS));
+
+        // All threads should succeed since not rate limited
+        assertEquals(threadCount, successCount.get());
+        assertEquals(0, exceptionCount.get());
+    }
+
+    @Test
+    void testConcurrentMixedOperations_300Threads() throws InterruptedException {
+        int threadCount = 300;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(threadCount);
+        AtomicInteger updateCount = new AtomicInteger(0);
+        AtomicInteger readCount = new AtomicInteger(0);
+        AtomicInteger checkCount = new AtomicInteger(0);
+
+        for (int i = 0; i < threadCount; i++) {
+            final int threadId = i;
+            executorService.submit(() -> {
+                try {
+                    startLatch.await();
+
+                    // Different operations based on thread ID
+                    if (threadId % 3 == 0) {
+                        // Update operation
+                        Instant resetTime = Instant.now().plusSeconds(60);
+                        tracker.updateRateLimit("api" + (threadId % 10) + ".example.com",
+                            100, 50, resetTime);
+                        updateCount.incrementAndGet();
+                    } else if (threadId % 3 == 1) {
+                        // Read operation
+                        tracker.getState("api" + (threadId % 10) + ".example.com");
+                        readCount.incrementAndGet();
+                    } else {
+                        // Check operation
+                        try {
+                            tracker.checkAndWait("api" + (threadId % 10) + ".example.com");
+                        } catch (RateLimitException e) {
+                            // Expected in some cases
+                        }
+                        checkCount.incrementAndGet();
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    endLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        assertTrue(endLatch.await(15, TimeUnit.SECONDS));
+
+        // Verify all operations completed
+        assertEquals(100, updateCount.get());
+        assertEquals(100, readCount.get());
+        assertEquals(100, checkCount.get());
+
+        // Verify tracker is in a valid state
+        assertTrue(tracker.size() <= 10); // At most 10 different keys
+    }
+
+    @Test
+    void testConcurrentUpdatesMultipleKeys_200Threads() throws InterruptedException {
+        int threadCount = 200;
+        int keyCount = 20;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            final int threadId = i;
+            executorService.submit(() -> {
+                try {
+                    startLatch.await();
+                    String key = "api" + (threadId % keyCount) + ".example.com";
+                    Instant resetTime = Instant.now().plusSeconds(60);
+                    tracker.updateRateLimit(key, 100, 50, resetTime);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    endLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        assertTrue(endLatch.await(10, TimeUnit.SECONDS));
+
+        // Verify we have exactly keyCount entries
+        assertEquals(keyCount, tracker.size());
+
+        // Verify all keys are present and have valid state
+        for (int i = 0; i < keyCount; i++) {
+            String key = "api" + i + ".example.com";
+            RateLimitState state = tracker.getState(key);
+            assertNotNull(state);
+            assertEquals(100, state.limit());
+            assertEquals(50, state.remaining());
+        }
+    }
+
+    @Test
+    void testConcurrentCleanup_100Threads() throws InterruptedException {
+        // Add expired and non-expired entries
+        Instant expiredReset = Instant.now().minusSeconds(1);
+        Instant futureReset = Instant.now().plusSeconds(60);
+
+        for (int i = 0; i < 50; i++) {
+            tracker.updateRateLimit("expired" + i + ".example.com", 100, 0, expiredReset);
+            tracker.updateRateLimit("active" + i + ".example.com", 100, 50, futureReset);
+        }
+
+        assertEquals(100, tracker.size());
+
+        int threadCount = 100;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(threadCount);
+
+        // Multiple threads calling cleanup concurrently
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    startLatch.await();
+                    tracker.cleanupExpiredEntries();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    endLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        assertTrue(endLatch.await(10, TimeUnit.SECONDS));
+
+        // Only active entries should remain
+        assertEquals(50, tracker.size());
+
+        // Verify expired entries are gone
+        for (int i = 0; i < 50; i++) {
+            assertNull(tracker.getState("expired" + i + ".example.com"));
+            assertNotNull(tracker.getState("active" + i + ".example.com"));
+        }
+    }
+
+    @Test
+    void testAtomicUpdateBehavior() throws InterruptedException {
+        int threadCount = 100;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(threadCount);
+
+        // All threads update the same key with different remaining values
+        for (int i = 0; i < threadCount; i++) {
+            final int remaining = i;
+            executorService.submit(() -> {
+                try {
+                    startLatch.await();
+                    Instant resetTime = Instant.now().plusSeconds(60);
+                    tracker.updateRateLimit("api.example.com", 100, remaining, resetTime);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    endLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        assertTrue(endLatch.await(10, TimeUnit.SECONDS));
+
+        // The final state should be from one of the threads (atomic operation)
+        RateLimitState state = tracker.getState("api.example.com");
+        assertNotNull(state);
+        assertEquals(100, state.limit());
+        assertTrue(state.remaining() >= 0 && state.remaining() < threadCount);
+    }
+
+    @Test
+    void testNoDataCorruption_StressTest() throws InterruptedException {
+        int threadCount = 500;
+        int iterations = 10;
+        CountDownLatch endLatch = new CountDownLatch(threadCount * iterations);
+
+        for (int iter = 0; iter < iterations; iter++) {
+            for (int i = 0; i < threadCount; i++) {
+                final int threadId = i;
+                final int iterationId = iter;
+                executorService.submit(() -> {
+                    try {
+                        String key = "api" + (threadId % 50) + ".example.com";
+                        Instant resetTime = Instant.now().plusSeconds(60);
+
+                        // Random operations
+                        if (threadId % 4 == 0) {
+                            tracker.updateRateLimit(key, 100, 50, resetTime);
+                        } else if (threadId % 4 == 1) {
+                            tracker.getState(key);
+                        } else if (threadId % 4 == 2) {
+                            try {
+                                tracker.checkAndWait(key);
+                            } catch (RateLimitException e) {
+                                // Expected
+                            }
+                        } else {
+                            if (iterationId % 2 == 0) {
+                                tracker.cleanupExpiredEntries();
+                            }
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    } finally {
+                        endLatch.countDown();
+                    }
+                });
+            }
+        }
+
+        assertTrue(endLatch.await(30, TimeUnit.SECONDS));
+
+        // Verify tracker is in a consistent state
+        assertTrue(tracker.size() <= 50);
+
+        // All entries should have valid state
+        for (int i = 0; i < 50; i++) {
+            String key = "api" + i + ".example.com";
+            RateLimitState state = tracker.getState(key);
+            if (state != null) {
+                assertTrue(state.limit() > 0);
+                assertTrue(state.remaining() >= 0);
+                assertNotNull(state.resetTime());
+                assertNotNull(state.lastUpdated());
+            }
+        }
+    }
+}

--- a/src/test/java/com/bavodaniels/ratelimit/tracker/RateLimitTrackerTest.java
+++ b/src/test/java/com/bavodaniels/ratelimit/tracker/RateLimitTrackerTest.java
@@ -1,0 +1,176 @@
+package com.bavodaniels.ratelimit.tracker;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RateLimitTrackerTest {
+
+    private RateLimitTracker tracker;
+
+    @BeforeEach
+    void setUp() {
+        tracker = new RateLimitTracker(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void testUpdateRateLimit() {
+        Instant resetTime = Instant.now().plusSeconds(60);
+        tracker.updateRateLimit("api.example.com", 100, 50, resetTime);
+
+        RateLimitState state = tracker.getState("api.example.com");
+        assertNotNull(state);
+        assertEquals(100, state.limit());
+        assertEquals(50, state.remaining());
+        assertEquals(resetTime, state.resetTime());
+    }
+
+    @Test
+    void testUpdateRateLimit_Overwrite() {
+        Instant resetTime1 = Instant.now().plusSeconds(60);
+        tracker.updateRateLimit("api.example.com", 100, 50, resetTime1);
+
+        Instant resetTime2 = Instant.now().plusSeconds(120);
+        tracker.updateRateLimit("api.example.com", 200, 75, resetTime2);
+
+        RateLimitState state = tracker.getState("api.example.com");
+        assertEquals(200, state.limit());
+        assertEquals(75, state.remaining());
+        assertEquals(resetTime2, state.resetTime());
+    }
+
+    @Test
+    void testCheckAndWait_NoRateLimit() throws Exception {
+        boolean result = tracker.checkAndWait("api.example.com");
+        assertTrue(result);
+    }
+
+    @Test
+    void testCheckAndWait_NotLimited() throws Exception {
+        Instant resetTime = Instant.now().plusSeconds(60);
+        tracker.updateRateLimit("api.example.com", 100, 50, resetTime);
+
+        boolean result = tracker.checkAndWait("api.example.com");
+        assertTrue(result);
+    }
+
+    @Test
+    void testCheckAndWait_Expired() throws Exception {
+        Instant resetTime = Instant.now().minusSeconds(1);
+        tracker.updateRateLimit("api.example.com", 100, 0, resetTime);
+
+        boolean result = tracker.checkAndWait("api.example.com");
+        assertTrue(result);
+    }
+
+    @Test
+    void testCheckAndWait_ShortWait() throws Exception {
+        Instant resetTime = Instant.now().plus(2, ChronoUnit.SECONDS);
+        tracker.updateRateLimit("api.example.com", 100, 0, resetTime);
+
+        long start = System.currentTimeMillis();
+        boolean result = tracker.checkAndWait("api.example.com");
+        long elapsed = System.currentTimeMillis() - start;
+
+        assertTrue(result);
+        assertTrue(elapsed >= 1500); // Should have waited ~2 seconds (accounting for some variance)
+    }
+
+    @Test
+    void testCheckAndWait_ExceedsThreshold() {
+        Instant resetTime = Instant.now().plusSeconds(10); // Beyond 5 second threshold
+        tracker.updateRateLimit("api.example.com", 100, 0, resetTime);
+
+        RateLimitException exception = assertThrows(RateLimitException.class, () -> {
+            tracker.checkAndWait("api.example.com");
+        });
+
+        assertTrue(exception.getMessage().contains("Rate limit exceeded"));
+        assertTrue(exception.getMessage().contains("api.example.com"));
+    }
+
+    @Test
+    void testCleanupExpiredEntries() {
+        Instant expiredReset = Instant.now().minusSeconds(1);
+        Instant futureReset = Instant.now().plusSeconds(60);
+
+        tracker.updateRateLimit("expired.example.com", 100, 0, expiredReset);
+        tracker.updateRateLimit("active.example.com", 100, 50, futureReset);
+
+        assertEquals(2, tracker.size());
+
+        tracker.cleanupExpiredEntries();
+
+        assertEquals(1, tracker.size());
+        assertNull(tracker.getState("expired.example.com"));
+        assertNotNull(tracker.getState("active.example.com"));
+    }
+
+    @Test
+    void testClear() {
+        Instant resetTime = Instant.now().plusSeconds(60);
+        tracker.updateRateLimit("api1.example.com", 100, 50, resetTime);
+        tracker.updateRateLimit("api2.example.com", 200, 75, resetTime);
+
+        assertEquals(2, tracker.size());
+
+        tracker.clear();
+
+        assertEquals(0, tracker.size());
+        assertNull(tracker.getState("api1.example.com"));
+        assertNull(tracker.getState("api2.example.com"));
+    }
+
+    @Test
+    void testBuildKey_WithEndpoint() {
+        String key = RateLimitTracker.buildKey("api.example.com", "/users");
+        assertEquals("api.example.com:/users", key);
+    }
+
+    @Test
+    void testBuildKey_WithoutEndpoint() {
+        String key = RateLimitTracker.buildKey("api.example.com", "");
+        assertEquals("api.example.com", key);
+    }
+
+    @Test
+    void testBuildKey_NullEndpoint() {
+        String key = RateLimitTracker.buildKey("api.example.com", null);
+        assertEquals("api.example.com", key);
+    }
+
+    @Test
+    void testCustomWaitThreshold() {
+        RateLimitTracker customTracker = new RateLimitTracker(Duration.ofMillis(100));
+        Instant resetTime = Instant.now().plusMillis(200);
+        customTracker.updateRateLimit("api.example.com", 100, 0, resetTime);
+
+        assertThrows(RateLimitException.class, () -> {
+            customTracker.checkAndWait("api.example.com");
+        });
+    }
+
+    @Test
+    void testMultipleKeys() {
+        Instant resetTime = Instant.now().plusSeconds(60);
+
+        tracker.updateRateLimit("api1.example.com", 100, 50, resetTime);
+        tracker.updateRateLimit("api2.example.com", 200, 75, resetTime);
+        tracker.updateRateLimit("api3.example.com:/users", 150, 25, resetTime);
+
+        assertEquals(3, tracker.size());
+
+        RateLimitState state1 = tracker.getState("api1.example.com");
+        RateLimitState state2 = tracker.getState("api2.example.com");
+        RateLimitState state3 = tracker.getState("api3.example.com:/users");
+
+        assertEquals(100, state1.limit());
+        assertEquals(200, state2.limit());
+        assertEquals(150, state3.limit());
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements a thread-safe rate limit tracker using `ConcurrentHashMap` to track rate limit state across different hosts and endpoints. The tracker handles concurrent requests from multiple threads without race conditions and provides automatic cleanup of expired entries.

### Key Components

1. **RateLimitState** - Immutable record class that stores rate limit information:
   - Rate limit (max requests allowed)
   - Remaining requests
   - Reset timestamp
   - Last updated timestamp
   - Helper methods to check if expired, limited, or calculate wait time

2. **RateLimitTracker** - Thread-safe tracker with:
   - `ConcurrentHashMap` storage for lock-free reads
   - Atomic updates using `compute()` operation
   - Configurable wait threshold (default 5 seconds)
   - Smart decision making: block if wait < threshold, throw exception if wait > threshold
   - Automatic cleanup via `@Scheduled` annotation (runs every minute)
   - Helper method to build keys from host/endpoint

3. **RateLimitException** - Custom exception thrown when rate limit wait time exceeds threshold

### Technical Implementation

- Uses `ConcurrentHashMap.compute()` for atomic state updates
- Immutable `RateLimitState` record ensures thread-safety
- No external concurrency libraries (pure JDK)
- Handles clock skew by checking if reset time has passed
- Supports both host-level and endpoint-level tracking via flexible key format

### Testing

Comprehensive test suite with **31 total tests**:

#### Unit Tests (23 tests)
- **RateLimitStateTest** (9 tests): Tests immutability, expiration logic, wait time calculation
- **RateLimitTrackerTest** (14 tests): Tests core functionality, cleanup, threshold behavior

#### Concurrency Tests (8 tests with 100-500 threads)
- `testConcurrentUpdates_100Threads` - Verifies atomic updates with 100 threads
- `testConcurrentReads_200Threads` - Ensures consistent reads with 200 threads  
- `testConcurrentCheckAndWait_150Threads_NotLimited` - Tests 150 concurrent check operations
- `testConcurrentMixedOperations_300Threads` - Simulates real-world scenario with 300 threads doing mixed operations
- `testConcurrentUpdatesMultipleKeys_200Threads` - Tests 200 threads updating 20 different keys
- `testConcurrentCleanup_100Threads` - Verifies 100 threads can safely call cleanup simultaneously
- `testAtomicUpdateBehavior` - Confirms atomic behavior with 100 threads updating same key
- `testNoDataCorruption_StressTest` - **Stress test with 5000 operations across 500 threads**

All tests pass successfully with no failures, errors, or data corruption.

## Test Plan

- [x] Unit tests for RateLimitState domain model
- [x] Unit tests for RateLimitTracker core functionality  
- [x] Thread-safety tests with 100+ concurrent threads
- [x] Stress test with 500 threads and 5000 operations
- [x] Tests for atomic updates
- [x] Tests for cleanup mechanism
- [x] Edge case tests (expired entries, threshold behavior, etc.)

## Resolves

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)