### PR TITLE
feat: Add RestClient rate limit interceptor (Issue #9)

### DIFF
--- a/src/test/java/com/bavodaniels/ratelimit/interceptor/RestClientRateLimitInterceptorConcurrentTest.java
+++ b/src/test/java/com/bavodaniels/ratelimit/interceptor/RestClientRateLimitInterceptorConcurrentTest.java
@@ -1,0 +1,243 @@
+package com.bavodaniels.ratelimit.interceptor;
+
+import com.bavodaniels.ratelimit.model.RateLimitState;
+import com.bavodaniels.ratelimit.tracker.InMemoryRateLimitTracker;
+import com.bavodaniels.ratelimit.tracker.RateLimitTracker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.mock.http.client.MockClientHttpResponse;
+import org.springframework.web.client.RestClient;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Concurrent integration tests for RestClient with RestTemplateRateLimitInterceptor.
+ * Tests thread-safety and concurrent request handling.
+ */
+class RestClientRateLimitInterceptorConcurrentTest {
+
+    private RateLimitTracker tracker;
+    private RestTemplateRateLimitInterceptor interceptor;
+    private RestClient restClient;
+
+    @BeforeEach
+    void setUp() {
+        tracker = new InMemoryRateLimitTracker();
+        interceptor = new RestTemplateRateLimitInterceptor(tracker, 5000);
+        restClient = RestClient.builder()
+                .requestFactory(createMockRequestFactory())
+                .requestInterceptor(interceptor)
+                .build();
+    }
+
+    @Test
+    void testConcurrentRequestsWithoutRateLimits() throws InterruptedException {
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+        List<Future<?>> futures = new ArrayList<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            futures.add(executor.submit(() -> {
+                try {
+                    String result = restClient.get()
+                            .uri("http://api.example.com/test")
+                            .retrieve()
+                            .body(String.class);
+                    if ("OK".equals(result)) {
+                        successCount.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    fail("Request failed: " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            }));
+        }
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS), "All requests should complete within 10 seconds");
+        assertEquals(threadCount, successCount.get(), "All requests should succeed");
+
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void testConcurrentRequestsWithRateLimits() throws InterruptedException {
+        String host = "api.example.com";
+
+        // Set up rate limit state
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-RateLimit-Limit", "100");
+        headers.set("X-RateLimit-Remaining", "50");
+        headers.set("X-RateLimit-Reset", String.valueOf(Instant.now().plusSeconds(60).getEpochSecond()));
+        tracker.updateFromHeaders(host, headers);
+
+        int threadCount = 5;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    restClient.get()
+                            .uri("http://" + host + "/test")
+                            .retrieve()
+                            .body(String.class);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    // Expected for some requests if rate limited
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS), "All requests should complete within 10 seconds");
+        assertTrue(successCount.get() > 0, "At least some requests should succeed");
+
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void testConcurrentRequestsWithWait() throws InterruptedException {
+        String host = "api.example.com";
+
+        // Set up a state that requires a short wait
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-RateLimit-Limit", "100");
+        headers.set("X-RateLimit-Remaining", "0");
+        headers.set("Retry-After", "1"); // 1 second wait
+        tracker.updateFromHeaders(host, headers);
+
+        int threadCount = 3;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        long startTime = System.currentTimeMillis();
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    restClient.get()
+                            .uri("http://" + host + "/test")
+                            .retrieve()
+                            .body(String.class);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    // Expected for some requests
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        assertTrue(latch.await(15, TimeUnit.SECONDS), "All requests should complete");
+        long elapsedTime = System.currentTimeMillis() - startTime;
+
+        // At least one thread should have waited
+        assertTrue(elapsedTime >= 900, "At least one request should have waited");
+        assertTrue(successCount.get() > 0, "At least some requests should succeed");
+
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void testConcurrentUpdatesFromMultipleHosts() throws InterruptedException {
+        int hostCount = 5;
+        int requestsPerHost = 3;
+        ExecutorService executor = Executors.newFixedThreadPool(hostCount * requestsPerHost);
+        CountDownLatch latch = new CountDownLatch(hostCount * requestsPerHost);
+
+        for (int h = 0; h < hostCount; h++) {
+            final String host = "api" + h + ".example.com";
+
+            for (int r = 0; r < requestsPerHost; r++) {
+                executor.submit(() -> {
+                    try {
+                        restClient.get()
+                                .uri("http://" + host + "/test")
+                                .retrieve()
+                                .body(String.class);
+                    } catch (Exception e) {
+                        // Ignore exceptions in this test
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+        }
+
+        assertTrue(latch.await(10, TimeUnit.SECONDS), "All requests should complete");
+
+        // Verify each host has its own state
+        for (int h = 0; h < hostCount; h++) {
+            String host = "api" + h + ".example.com";
+            RateLimitState state = tracker.getState(host);
+            assertNotNull(state, "State should exist for " + host);
+        }
+
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void testConcurrentBuilderCreation() throws InterruptedException {
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        List<RestClient> clients = new CopyOnWriteArrayList<>();
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    RestClient client = RestClient.builder()
+                            .requestFactory(createMockRequestFactory())
+                            .requestInterceptor(interceptor)
+                            .build();
+                    clients.add(client);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        assertTrue(latch.await(5, TimeUnit.SECONDS), "All clients should be created");
+        assertEquals(threadCount, clients.size(), "All clients should be created successfully");
+
+        executor.shutdown();
+        assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+    }
+
+    // Helper method to create a mock request factory for testing
+    private ClientHttpRequestFactory createMockRequestFactory() {
+        return (uri, httpMethod) -> new org.springframework.mock.http.client.MockClientHttpRequest(httpMethod, uri) {
+            @Override
+            public ClientHttpResponse executeInternal() throws IOException {
+                HttpHeaders responseHeaders = new HttpHeaders();
+                responseHeaders.set("X-RateLimit-Limit", "100");
+                responseHeaders.set("X-RateLimit-Remaining", "99");
+
+                MockClientHttpResponse response = new MockClientHttpResponse("OK".getBytes(), HttpStatus.OK);
+                response.getHeaders().putAll(responseHeaders);
+                return response;
+            }
+        };
+    }
+}

--- a/src/test/java/com/bavodaniels/ratelimit/interceptor/RestClientRateLimitInterceptorTest.java
+++ b/src/test/java/com/bavodaniels/ratelimit/interceptor/RestClientRateLimitInterceptorTest.java
@@ -1,0 +1,167 @@
+package com.bavodaniels.ratelimit.interceptor;
+
+import com.bavodaniels.ratelimit.exception.RateLimitExceededException;
+import com.bavodaniels.ratelimit.model.RateLimitState;
+import com.bavodaniels.ratelimit.tracker.InMemoryRateLimitTracker;
+import com.bavodaniels.ratelimit.tracker.RateLimitTracker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.mock.http.client.MockClientHttpResponse;
+import org.springframework.web.client.RestClient;
+
+import java.io.IOException;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for RestClient with RestTemplateRateLimitInterceptor.
+ * Demonstrates that the same interceptor can be used for both RestTemplate and RestClient
+ * since they share the ClientHttpRequestInterceptor interface.
+ */
+class RestClientRateLimitInterceptorTest {
+
+    private RateLimitTracker tracker;
+    private RestTemplateRateLimitInterceptor interceptor;
+    private RestClient restClient;
+
+    @BeforeEach
+    void setUp() {
+        tracker = new InMemoryRateLimitTracker();
+        interceptor = new RestTemplateRateLimitInterceptor(tracker, 5000); // 5 second threshold
+
+        // Create a RestClient with the rate limit interceptor
+        restClient = RestClient.builder()
+                .requestFactory(createMockRequestFactory())
+                .requestInterceptor(interceptor)
+                .build();
+    }
+
+    @Test
+    void testRestClientWithNoRateLimitHeaders() {
+        // Should successfully make a request without rate limit headers
+        assertDoesNotThrow(() -> {
+            String result = restClient.get()
+                    .uri("http://api.example.com/test")
+                    .retrieve()
+                    .body(String.class);
+            assertEquals("OK", result);
+        });
+    }
+
+    @Test
+    void testRestClientWithRateLimitHeaders() {
+        // Make a request that will populate rate limit headers
+        assertDoesNotThrow(() -> {
+            restClient.get()
+                    .uri("http://api.example.com/with-headers")
+                    .retrieve()
+                    .body(String.class);
+        });
+
+        // Verify state was updated from headers
+        RateLimitState state = tracker.getState("api.example.com");
+        assertNotNull(state);
+        assertEquals(100, state.getLimit());
+        assertEquals(50, state.getRemaining());
+    }
+
+    @Test
+    void testRestClientWithRateLimitExceeded() {
+        String host = "api.example.com";
+
+        // Set up a state that requires waiting beyond threshold
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-RateLimit-Limit", "100");
+        headers.set("X-RateLimit-Remaining", "0");
+        headers.set("Retry-After", "10"); // 10 seconds - exceeds our 5 second threshold
+
+        tracker.updateFromHeaders(host, headers);
+
+        // Should throw RateLimitExceededException
+        RateLimitExceededException exception = assertThrows(RateLimitExceededException.class, () -> {
+            restClient.get()
+                    .uri("http://" + host + "/test")
+                    .retrieve()
+                    .body(String.class);
+        });
+
+        assertEquals(host, exception.getHost());
+        assertEquals(10000, exception.getWaitTimeMillis());
+        assertEquals(5000, exception.getThresholdMillis());
+    }
+
+    @Test
+    void testRestClientWithShortWait() {
+        String host = "api.example.com";
+
+        // Set up a state that requires a short wait (under threshold)
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-RateLimit-Limit", "100");
+        headers.set("X-RateLimit-Remaining", "0");
+        headers.set("X-RateLimit-Reset", String.valueOf(Instant.now().plusSeconds(10).getEpochSecond()));
+        headers.set("Retry-After", "2"); // 2 seconds - under threshold
+
+        tracker.updateFromHeaders(host, headers);
+
+        // Should wait approximately 2 seconds before making the request
+        long startTime = System.currentTimeMillis();
+        assertDoesNotThrow(() -> {
+            restClient.get()
+                    .uri("http://" + host + "/test")
+                    .retrieve()
+                    .body(String.class);
+        });
+        long elapsedTime = System.currentTimeMillis() - startTime;
+
+        assertTrue(elapsedTime >= 1800, "Should have waited at least 1.8 seconds, but was " + elapsedTime + "ms");
+        assertTrue(elapsedTime < 3000, "Should not have waited more than 3 seconds, but was " + elapsedTime + "ms");
+    }
+
+    @Test
+    void testRestClientBuilderWithInterceptor() {
+        // Verify that the interceptor is properly configured
+        assertNotNull(interceptor);
+        assertEquals(tracker, interceptor.getRateLimitTracker());
+        assertEquals(5000, interceptor.getMaxWaitTimeMillis());
+    }
+
+    @Test
+    void testRestClientWithCustomPort() {
+        assertDoesNotThrow(() -> {
+            restClient.get()
+                    .uri("http://api.example.com:8080/test")
+                    .retrieve()
+                    .body(String.class);
+        });
+
+        // Verify state was stored with port
+        RateLimitState state = tracker.getState("api.example.com:8080");
+        assertNotNull(state);
+    }
+
+    // Helper method to create a mock request factory for testing
+    private ClientHttpRequestFactory createMockRequestFactory() {
+        return (uri, httpMethod) -> new org.springframework.mock.http.client.MockClientHttpRequest(httpMethod, uri) {
+            @Override
+            public ClientHttpResponse executeInternal() throws IOException {
+                HttpHeaders responseHeaders = new HttpHeaders();
+
+                // Add rate limit headers for specific test URIs
+                if (uri.toString().contains("with-headers")) {
+                    responseHeaders.set("X-RateLimit-Limit", "100");
+                    responseHeaders.set("X-RateLimit-Remaining", "50");
+                    responseHeaders.set("X-RateLimit-Reset", String.valueOf(Instant.now().plusSeconds(60).getEpochSecond()));
+                }
+
+                MockClientHttpResponse response = new MockClientHttpResponse("OK".getBytes(), HttpStatus.OK);
+                response.getHeaders().putAll(responseHeaders);
+                return response;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- Added integration tests for RestClient with rate limit interceptor
- Demonstrates that RestClient (Spring 6.1+) can use the existing RestTemplateRateLimitInterceptor
- Both RestClient and RestTemplate share the same ClientHttpRequestInterceptor interface

## Changes
- Created `RestClientRateLimitInterceptorTest` with comprehensive integration tests
- Created `RestClientRateLimitInterceptorConcurrentTest` for concurrent usage testing
- Tests verify rate limit header processing, blocking behavior, and exception handling

## Test Plan
- [x] Basic RestClient usage with rate limit interceptor
- [x] Rate limit header processing from responses
- [x] Wait time handling and thread blocking
- [x] Exception throwing when wait time exceeds threshold  
- [x] Concurrent requests with rate limits
- [x] Multiple hosts support
- [x] RestClient.Builder configuration

## Notes
Since RestClient uses the same `ClientHttpRequestInterceptor` interface as RestTemplate, no new interceptor class is needed. The existing `RestTemplateRateLimitInterceptor` can be used directly with both clients.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)